### PR TITLE
h3: move plugin vfdcontrol from image to feed

### DIFF
--- a/conf/machine/h3.conf
+++ b/conf/machine/h3.conf
@@ -12,4 +12,4 @@ RCTYPE = "21"
 
 require conf/machine/include/zgemma.inc
 
-MACHINE_EXTRA_RDEPENDS += "enigma2-plugin-extensions-vfdcontrol"
+OPTIONAL_BSP_ENIGMA2_PACKAGES += "enigma2-plugin-extensions-vfdcontrol"


### PR DESCRIPTION
In this receiver is used skin_text.xml in which using converter VfdDisplay can introduce the same functionality as in the plugin.
Therefore it is not necessary to use the plugin together with skin_text.xml which is used in any case.
If anyone still wants to use this plugin, he can be installed from the feed.