### PR TITLE
fixed incorrect path to zImage

### DIFF
--- a/conf/machine/include/zgemma.inc
+++ b/conf/machine/include/zgemma.inc
@@ -34,7 +34,7 @@ IMAGE_CMD_zgemma-emmc_append_arm = "\
 	cd ${IMAGE_ROOTFS}; \
 	tar -cvf ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.tar -C ${IMAGE_ROOTFS} .; \
 	bzip2 -f ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.tar; \
-	cp ${IMAGE_ROOTFS}/tmp/zImage ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
+	cp ${DEPLOY_DIR_IMAGE}/zImage ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
 	cd ${IMGDEPLOYDIR}; \
 	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_usb.zip ${IMAGEDIR}/disk.img ${IMAGEDIR}/imageversion; \
 	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_multiboot_ofgwrite.zip ${IMAGEDIR}/imageversion ${IMAGEDIR}/kernel.bin ${IMAGEDIR}/rootfs.tar.bz2; \


### PR DESCRIPTION
IMAGE_ROOTFS doesn't exist if do_rootfs() hasn't run, for example if
there were no changes, causing a failure to create the image due to a
file not found error.