### PR TITLE
zgemma-dvb-modules-h9.bb: check 'suspend' initscript argument

### DIFF
--- a/recipes-bsp/drivers/zgemma-dvb-modules-h9.bb
+++ b/recipes-bsp/drivers/zgemma-dvb-modules-h9.bb
@@ -21,6 +21,11 @@ do_compile_append () {
 	cat > suspend << EOF
 #!/bin/sh
 
+if [ "$1x" == "stopx" ]
+then
+	exit 0
+fi
+
 mount -t sysfs sys /sys
 
 /usr/bin/turnoff_power


### PR DESCRIPTION
The 'suspend' script should only be executed when called with a 'start'
argument.

opkg update calls '/etc/init.d/suspend stop' (from the update-rc.d prerm
hook).
This aborts the update process.
The script should exit when called with a 'stop' argument.