### PR TITLE
Disable anything auto depending on zgemma-libs fix #26

### DIFF
--- a/recipes-bsp/drivers/zgemma-libs.inc
+++ b/recipes-bsp/drivers/zgemma-libs.inc
@@ -12,6 +12,9 @@ S = "${WORKDIR}"
 
 INHIBIT_PACKAGE_STRIP = "1"
 
+# Disable anything auto depending on zgemma-libs
+EXCLUDE_FROM_SHLIBS = "1"
+
 # The driver is a set of binary libraries to install
 # there's nothing to configure or compile
 do_configure[noexec] = "1"


### PR DESCRIPTION
Zgemma-libs contains prebuilded libraries which duplicate existing.
Therefore when creating a package bitbake registering zgemma-libs as shlib provider for these libraries, and all packages that are built after and depends on these libraries depends also from zgemma-libs.
So use EXCLUDE_FROM_SHLIBS to disable generating shlibs providers for zgemma-libs prebuilded libraries and fix auto depending on zgemma-libs.