### PR TITLE
Follow PLi image names

### DIFF
--- a/conf/machine/include/zgemma-cortex-a15.inc
+++ b/conf/machine/include/zgemma-cortex-a15.inc
@@ -45,7 +45,7 @@ IMAGE_CMD_zgemmc_append = "\
 	cp ${DEPLOY_DIR_IMAGE}/zImage ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
 	cp ${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.tar.bz2 ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.tar.bz2; \
 	cd ${IMGDEPLOYDIR}; \
-	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_usb.zip ${IMAGEDIR}/disk.img ${IMAGEDIR}/imageversion; \
-	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_multiboot_ofgwrite.zip ${IMAGEDIR}/imageversion ${IMAGEDIR}/kernel.bin ${IMAGEDIR}/rootfs.tar.bz2; \
+	zip ${IMAGE_NAME}_usb.zip ${IMAGEDIR}/disk.img ${IMAGEDIR}/imageversion; \
+	zip ${IMAGE_NAME}_multiboot_ofgwrite.zip ${IMAGEDIR}/imageversion ${IMAGEDIR}/kernel.bin ${IMAGEDIR}/rootfs.tar.bz2; \
 	rm -Rf ${IMAGEDIR}; \
 	"

--- a/conf/machine/include/zgemma-hisil-3798mv200.inc
+++ b/conf/machine/include/zgemma-hisil-3798mv200.inc
@@ -76,7 +76,7 @@ IMAGE_CMD_fastboot4gb_append = " \
 	cp ${DEPLOY_DIR_IMAGE}/zgemma-partitions-${MACHINE}/${MACHINE}/logo.img ${IMGDEPLOYDIR}/${IMAGEDIR}/${MACHINE}/logo.img; \
 	echo "${IMAGEVERSION}" > ${IMGDEPLOYDIR}/${IMAGEDIR}/${MACHINE}/imageversion; \
 	cd ${IMGDEPLOYDIR}/${IMAGEDIR}; \
-	zip -r ../${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_emmc.zip *; \
+	zip -r ../${IMAGE_NAME}_emmc.zip *; \
 	cd ..; \
 	rm -Rf ${IMAGEDIR}; \
 	"
@@ -96,7 +96,7 @@ IMAGE_CMD_fastboot8gb_append = " \
 	cp ${DEPLOY_DIR_IMAGE}/zgemma-partitions-${MACHINE}/${MACHINE}/logo.img ${IMGDEPLOYDIR}/${IMAGEDIR}/${MACHINE}/logo.img; \
 	echo "${IMAGEVERSION}" > ${IMGDEPLOYDIR}/${IMAGEDIR}/${MACHINE}/imageversion; \
 	cd ${IMGDEPLOYDIR}/${IMAGEDIR}; \
-	zip -r ../${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_emmc.zip *; \
+	zip -r ../${IMAGE_NAME}_emmc.zip *; \
 	cd ..; \
 	rm -Rf ${IMAGEDIR}; \
 	"

--- a/conf/machine/include/zgemma-mipsel.inc
+++ b/conf/machine/include/zgemma-mipsel.inc
@@ -53,6 +53,6 @@ IMAGE_CMD_ubi_append = " \
 		echo "rename this file to 'force' to force an update without confirmation" > ${IMGDEPLOYDIR}/${IMAGEDIR}/noforce; \
 	fi; \
 	cd ${IMGDEPLOYDIR}; \
-	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_usb.zip ${IMAGEDIR}/*; \
+	zip ${IMAGE_NAME}_usb.zip ${IMAGEDIR}/*; \
 	rm -Rf ${IMAGEDIR}; \
 	"


### PR DESCRIPTION
Using "${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}" is wrong as the PLi's standard is https://github.com/OpenPLi/openpli-oe-core/blob/develop/meta-openpli/conf/distro/openpli-common.conf#L20

So simply use "${IMAGE_NAME}" like all other metas.