### PR TITLE
zeus: python should use 4 spaces indentation

### DIFF
--- a/recipes-bsp/linux/linux-zgemma_4.10.12.bb
+++ b/recipes-bsp/linux/linux-zgemma_4.10.12.bb
@@ -19,10 +19,10 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/linux-${PV}/COPYING;md5=d7810fab7487fb0aad
 # By default, kernel.bbclass modifies package names to allow multiple kernels
 # to be installed in parallel. We revert this change and rprovide the versioned
 # package names instead, to allow only one kernel to be installed.
-PKG_kernel-base = "kernel-base"
-PKG_kernel-image = "kernel-image"
-RPROVIDES_kernel-base = "kernel-${KERNEL_VERSION}"
-RPROVIDES_kernel-image = "kernel-image-${KERNEL_VERSION}"
+PKG_${KERNEL_PACKAGE_NAME}-base = "kernel-base"
+PKG_${KERNEL_PACKAGE_NAME}-image = "kernel-image"
+RPROVIDES_${KERNEL_PACKAGE_NAME}-base = "kernel-${KERNEL_VERSION}"
+RPROVIDES_${KERNEL_PACKAGE_NAME}-image = "kernel-image-${KERNEL_VERSION}"
 
 SRC_URI += "http://www.zgemma.org/downloads/linux-${PV}-${ARCH}.tar.gz;name=${ARCH} \
 	file://defconfig \
@@ -70,7 +70,7 @@ pkg_postinst_kernel-image_mipsel() {
 KERNEL_IMAGETYPE_arm = "zImage"
 KERNEL_OUTPUT_arm = "arch/${ARCH}/boot/${KERNEL_IMAGETYPE}"
 
-FILES_kernel-image_arm = "/${KERNEL_IMAGEDEST}/findkerneldevice.sh"
+FILES_${KERNEL_PACKAGE_NAME}-image_arm = "/${KERNEL_IMAGEDEST}/findkerneldevice.sh"
 
 kernel_do_configure_prepend_arm() {
 	install -d ${B}/usr

--- a/recipes-bsp/linux/linux-zgemma_4.4.35.bb
+++ b/recipes-bsp/linux/linux-zgemma_4.4.35.bb
@@ -38,10 +38,10 @@ SRC_URI_append_i55plus += " \
 # By default, kernel.bbclass modifies package names to allow multiple kernels
 # to be installed in parallel. We revert this change and rprovide the versioned
 # package names instead, to allow only one kernel to be installed.
-PKG_kernel-base = "kernel-base"
-PKG_kernel-image = "kernel-image"
-RPROVIDES_kernel-base = "kernel-${KERNEL_VERSION}"
-RPROVIDES_kernel-image = "kernel-image-${KERNEL_VERSION}"
+PKG_${KERNEL_PACKAGE_NAME}-base = "kernel-base"
+PKG_${KERNEL_PACKAGE_NAME}-image = "kernel-image"
+RPROVIDES_${KERNEL_PACKAGE_NAME}-base = "kernel-${KERNEL_VERSION}"
+RPROVIDES_${KERNEL_PACKAGE_NAME}-image = "kernel-image-${KERNEL_VERSION}"
 
 S = "${WORKDIR}/linux-${PV}"
 
@@ -52,9 +52,9 @@ KERNEL_IMAGETYPE = "uImage"
 KERNEL_OUTPUT = "arch/${ARCH}/boot/${KERNEL_IMAGETYPE}"
 
 
-FILES_kernel-image_h9 = " "
-FILES_kernel-image_i5plus = " "
-FILES_kernel-image = "/${KERNEL_IMAGEDEST}/findkerneldevice.sh"
+FILES_${KERNEL_PACKAGE_NAME}-image_h9 = " "
+FILES_${KERNEL_PACKAGE_NAME}-image_i5plus = " "
+FILES_${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/findkerneldevice.sh"
 
 kernel_do_configure_prepend() {
 	install -d ${B}/usr

--- a/recipes-bsp/mali/kernel-module-mali-utgard.inc
+++ b/recipes-bsp/mali/kernel-module-mali-utgard.inc
@@ -36,18 +36,18 @@ do_install_append() {
 FILES_${PN} += "${sysconfdir}/modules-load.d/_mali.conf"
 
 python() {
-	platform = d.getVar('MALI_DRIVER_PLATFORM', True)
-	if not platform:
-		platform = "devicetree"
-		TARGET_PLATFORM=" mali450"
+    platform = d.getVar('MALI_DRIVER_PLATFORM', True)
+    if not platform:
+        platform = "devicetree"
+        TARGET_PLATFORM=" mali450"
 
-	config = ["CONFIG_MALI_SHARED_INTERRUPTS=y",
-		"CONFIG_MALI400=m",
-		"CONFIG_MALI450=y",
-		"CONFIG_MALI_DVFS=y",
-		"CONFIG_GPU_AVS_ENABLE=y"]
+    config = ["CONFIG_MALI_SHARED_INTERRUPTS=y",
+        "CONFIG_MALI400=m",
+        "CONFIG_MALI450=y",
+        "CONFIG_MALI_DVFS=y",
+        "CONFIG_GPU_AVS_ENABLE=y"]
 
-	for c in config:
-		d.appendVar('MALI_FLAGS', '-D' + c + ' ')
-		d.appendVar('MALI_KCONFIG', c + ' ')
+    for c in config:
+        d.appendVar('MALI_FLAGS', '-D' + c + ' ')
+        d.appendVar('MALI_KCONFIG', c + ' ')
 }


### PR DESCRIPTION
This commit fixes the following warnings from bitbake:
WARNING: /zeus/meta-zgemma/recipes-bsp/mali/kernel-module-mali-3798mv200_r7p0-00rel0.bb: python should use 4 spaces indentation, but found tabs in kernel-module-mali-utgard.inc, line 39
...
WARNING: /zeus/meta-zgemma/recipes-bsp/mali/kernel-module-mali-3798mv200_r7p0-00rel0.bb: python should use 4 spaces indentation, but found tabs in kernel-module-mali-utgard.inc, line 52