### PR TITLE
fix xbox one tuner

### DIFF
--- a/recipes-bsp/linux/files/0005-xbox-one-tuner-4.10.patch
+++ b/recipes-bsp/linux/files/0005-xbox-one-tuner-4.10.patch
@@ -226,7 +226,7 @@ index b29d4894..d48a8a53 100644
 +		.num_device_descs = 1,
 +		.devices = {
 +			{ "Microsoft Xbox One Digital TV Tuner",
-+				{ &dib0700_usb_id_table[86], NULL },
++				{ &dib0700_usb_id_table[83], NULL },
 +				{ NULL },
 +			},
 +		},

--- a/recipes-bsp/linux/files/0005-xbox-one-tuner-4.4.patch
+++ b/recipes-bsp/linux/files/0005-xbox-one-tuner-4.4.patch
@@ -226,7 +226,7 @@ index e1316c7b..2b6c9d3c 100644
 +		.num_device_descs = 1,
 +		.devices = {
 +			{ "Microsoft Xbox One Digital TV Tuner",
-+				{ &dib0700_usb_id_table[86], NULL },
++				{ &dib0700_usb_id_table[83], NULL },
 +				{ NULL },
 +			},
 +		},


### PR DESCRIPTION
usb 1-1: new high-speed USB device number 3 using ehci-platform
dvb-usb: found a 'Microsoft Xbox One Digital TV Tuner' in cold state, will try to load a firmware
dvb-usb: downloading firmware from file 'dvb-usb-dib0700-1.20.fw'
dib0700: firmware started successfully.
dvb-usb: found a 'Microsoft Xbox One Digital TV Tuner' in warm state.
dvb-usb: will pass the complete MPEG2 transport stream to the software demuxer.
DVB: registering new adapter (Microsoft Xbox One Digital TV Tuner)
mn88472: module is from the staging directory, the quality is unknown, you have been warned.
mn88472 3-0018: Panasonic MN88472 successfully identified
tda18250 3-0060: NXP TDA18250BHN/M successfully identified
usb 1-1: DVB: registering adapter 1 frontend 0 (Panasonic MN88472)...
dvb-usb: Microsoft Xbox One Digital TV Tuner successfully initialized and connected.
usbcore: registered new interface driver dvb_usb_dib0700