### PR TITLE
h7.conf: rename v3d-nxpl-> v3d-cortexa15

### DIFF
--- a/conf/machine/h7.conf
+++ b/conf/machine/h7.conf
@@ -2,7 +2,7 @@
 #@NAME: h7
 #@DESCRIPTION: Machine configuration for the h7
 
-MACHINE_FEATURES += " textlcd 7segment dvb-c v3d-nxpl emmc"
+MACHINE_FEATURES += " textlcd 7segment dvb-c v3d-cortexa15 emmc"
 OPENPLI_FEATURES += " ci qtplugins kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/include/zgemma-cortex-a15.inc
+++ b/conf/machine/include/zgemma-cortex-a15.inc
@@ -23,10 +23,6 @@ require conf/machine/include/zgemma-essential.inc
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 
-# Kodi
-EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
-EXTRA_OECMAKE_append_pn-kodi += " -DWITH_V3D=nxpl"
-
 MACHINE_EXTRA_RRECOMMENDS = " \
 	gst-plugin-dvbmediasink \
 	ntfs-3g \

--- a/conf/machine/include/zgemma-essential.inc
+++ b/conf/machine/include/zgemma-essential.inc
@@ -12,7 +12,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "\
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "\
 	kernel-module-cdfs \
 	\
-	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'zgemma-v3ddriver-${MACHINE}' , '', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-cortexa15', 'zgemma-v3ddriver-${MACHINE}' , '', d)} \
 	\
 	${@bb.utils.contains('MACHINE_FEATURES', 'bluetooth', 'kernel-module-btusb bluez5' , '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'hisil-3798mv200 ciplus-helper', 'ciplus-helper-3798mv200' , '', d)} \

--- a/conf/machine/include/zgemma-hisil-3798mv200.inc
+++ b/conf/machine/include/zgemma-hisil-3798mv200.inc
@@ -32,9 +32,6 @@ EXTRA_OECONF_append_pn-enigma2 += " --with-alphablendingacceleration=always --wi
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 
-# Kodi
-EXTRA_OECONF_append_pn-kodi += " --with-gpu=mali --enable-player=hiplayer"
-
 MACHINE_EXTRA_RRECOMMENDS = " \
 	ffmpeg \
 	ntfs-3g \

--- a/conf/machine/include/zgemma-hisil-3798mv310.inc
+++ b/conf/machine/include/zgemma-hisil-3798mv310.inc
@@ -32,9 +32,6 @@ EXTRA_OECONF_append_pn-enigma2 += " --with-alphablendingacceleration=always --wi
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 
-# Kodi
-EXTRA_OECONF_append_pn-kodi += " --with-gpu=mali --enable-player=hiplayer"
-
 MACHINE_EXTRA_RRECOMMENDS = " \
 	ffmpeg \
 	ntfs-3g \

--- a/conf/machine/include/zgemma-mipsel.inc
+++ b/conf/machine/include/zgemma-mipsel.inc
@@ -24,7 +24,6 @@ require conf/machine/include/tune-mips32.inc
 require conf/machine/include/zgemma-essential.inc
 
 PACKAGECONFIG_GL_pn-qtbase = " gles2 linuxfb"
-EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
 
 MACHINE_EXTRA_RRECOMMENDS = " \
 	gst-plugin-dvbmediasink \


### PR DESCRIPTION
for kodi, use the same naming as in OE-A and OpenPLi

 While there remove EXTRA_OECONF_append_pn-kodi and
 EXTRA_OECMAKE_append_pn-kodi.
 In kodi > 18 this is now unnecessary in the machine conf files,
 it is derived from MACHINE_FEATURES.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>